### PR TITLE
Fix logic mistake and typo in variable check

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Grab frames from a RTSP stream and publish them to Prusa connect
 
 ```bash
 # Update the environment variables to suit your needs
-# PRUSA_CONNECT_FINGERPRINT is a unique string that you can choose.
+# PRUSA_CONNECT_FINGERPRINT is a unique string that you can choose (16 characters or more).
 # A UUID works well. Ex: https://duckduckgo.com/?hps=1&q=uuid&atb=v363-1&ia=answer
 docker run \
     -e PRUSA_CONNECT_RTSP_URL="rtsp://USERNAME:PASSWORD@HOSTNAMEorIP:554/stream1" \

--- a/prusa_connect_rtsp/main.py
+++ b/prusa_connect_rtsp/main.py
@@ -50,7 +50,7 @@ def main():
     if not snapshot_api_url:
         raise ValueError("ENVVAR PRUSA_CONNECT_URL is required")
     fingerprint = os.getenv("PRUSA_CONNECT_FINGERPRINT").strip().strip("\"'")
-    if not rtsp_url:
+    if not fingerprint:
         raise ValueError("ENVVAR PRUSA_CONNECT_FINGERPRINT is required. Set it to a random UUID.")
     api_token = os.getenv("PRUSA_CONNECT_TOKEN").strip().strip("\"'")
     if not api_token:
@@ -62,8 +62,9 @@ def main():
             if success:
                 upload_response = upload_image(snapshot_api_url, fingerprint, api_token, image.data)
 
-                if 299 < upload_response.status_code < 200:
+                if not (200 < upload_response.status_code < 299):
                     logger.error("Failed to upload image to prusa connect")
+                    logger.debug(str(upload_response.content))
                 else:
                     logger.debug("Image uploaded")
             else:


### PR DESCRIPTION
I made those edits in the github editor, so I haven't tested them extensively.

`299 < upload_response.status_code < 200` will always be `false`

I also added an output of the error response.
...like `"{detail":[{"type":"string_too_short","loc":["header","Fingerprint"],"msg":"String should have at least 16 characters","input":"prusacam","ctx":{"min_length":16}}]}`...